### PR TITLE
fix: 新しいトピック作成時の重複リクエスト問題を解決

### DIFF
--- a/app/api/topics/[id]/route.ts
+++ b/app/api/topics/[id]/route.ts
@@ -68,6 +68,26 @@ export async function PUT(
       return NextResponse.json({ error: "Title is required" }, { status: 400 });
     }
 
+    // タイトルの重複チェック（自分自身以外で重複していないか確認）
+    const existingTopic = await prisma.topic.findFirst({
+      where: {
+        title: {
+          equals: title,
+          mode: "insensitive",
+        },
+        NOT: {
+          id: id,
+        },
+      },
+    });
+
+    if (existingTopic) {
+      return NextResponse.json(
+        { error: "Topic with this title already exists" },
+        { status: 409 }
+      );
+    }
+
     //topic update
     const topic = await prisma.topic.update({
       where: { id },

--- a/app/api/topics/route.ts
+++ b/app/api/topics/route.ts
@@ -63,6 +63,23 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Title is required" }, { status: 400 });
     }
 
+    // タイトルの重複チェック
+    const existingTopic = await prisma.topic.findFirst({
+      where: {
+        title: {
+          equals: title,
+          mode: "insensitive",
+        },
+      },
+    });
+
+    if (existingTopic) {
+      return NextResponse.json(
+        { error: "Topic with this title already exists" },
+        { status: 409 }
+      );
+    }
+
     // トピックを作成
     const topic = await prisma.topic.create({
       data: {

--- a/components/bookmark-manager-client.tsx
+++ b/components/bookmark-manager-client.tsx
@@ -137,6 +137,8 @@ export const BookmarkManagerClient: React.FC<BookmarkManagerClientProps> = ({
           onTopicCreate={handleTopicCreate}
           showTopicModal={modalsHook.showTopicModal}
           setShowTopicModal={modalsHook.setShowTopicModal}
+          isCreating={topicsHook.isCreating}
+          isDeleting={topicsHook.isDeleting}
         />
 
         <SidebarInset className="flex-1">
@@ -243,6 +245,8 @@ export const BookmarkManagerClient: React.FC<BookmarkManagerClientProps> = ({
         topicForm={topicsHook.topicForm}
         setTopicForm={topicsHook.setTopicForm}
         onSubmit={handleTopicModalSubmit}
+        isCreating={topicsHook.isCreating}
+        isUpdating={topicsHook.isUpdating}
       />
 
       <BookmarkModal

--- a/components/modals/topic-modal.tsx
+++ b/components/modals/topic-modal.tsx
@@ -35,6 +35,8 @@ interface TopicModalProps {
     }>
   >;
   onSubmit: () => void;
+  isCreating?: boolean;
+  isUpdating?: boolean;
 }
 
 export const TopicModal: React.FC<TopicModalProps> = ({
@@ -44,6 +46,8 @@ export const TopicModal: React.FC<TopicModalProps> = ({
   topicForm,
   setTopicForm,
   onSubmit,
+  isCreating = false,
+  isUpdating = false,
 }) => {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -150,10 +154,10 @@ export const TopicModal: React.FC<TopicModalProps> = ({
           </Button>
           <Button
             onClick={onSubmit}
-            disabled={!topicForm.title.trim()}
-            className="bg-gradient-to-r from-amber-500 to-orange-500 hover:opacity-80 text-white rounded-xl shadow-sm"
+            disabled={!topicForm.title.trim() || isCreating || isUpdating}
+            className="bg-gradient-to-r from-amber-500 to-orange-500 hover:opacity-80 text-white rounded-xl shadow-sm disabled:opacity-50"
           >
-            {editingTopic ? "更新" : "作成"}
+            {isCreating || isUpdating ? "処理中..." : editingTopic ? "更新" : "作成"}
           </Button>
         </div>
       </DialogContent>

--- a/components/topic-sidebar.tsx
+++ b/components/topic-sidebar.tsx
@@ -46,6 +46,8 @@ interface TopicSidebarProps {
   onTopicCreate: () => void;
   showTopicModal: boolean;
   setShowTopicModal: (show: boolean) => void;
+  isCreating?: boolean;
+  isDeleting?: boolean;
 }
 
 export const TopicSidebar: React.FC<TopicSidebarProps> = ({
@@ -57,6 +59,8 @@ export const TopicSidebar: React.FC<TopicSidebarProps> = ({
   onTopicCreate,
   showTopicModal,
   setShowTopicModal,
+  isCreating = false,
+  isDeleting = false,
 }) => {
   return (
     <Sidebar className="border-r border-sidebar-border bg-sidebar shadow-sm">
@@ -89,8 +93,9 @@ export const TopicSidebar: React.FC<TopicSidebarProps> = ({
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-6 w-6 p-0 hover:bg-sidebar-accent text-sidebar-foreground"
+                  className="h-6 w-6 p-0 hover:bg-sidebar-accent text-sidebar-foreground disabled:opacity-50"
                   onClick={onTopicCreate}
+                  disabled={isCreating}
                 >
                   <Plus className="h-3 w-3" />
                 </Button>
@@ -149,7 +154,8 @@ export const TopicSidebar: React.FC<TopicSidebarProps> = ({
                               // イベントバブリングを防止してトピック選択を回避
                               e.stopPropagation();
                             }}
-                            className="p-1.5 text-muted-foreground hover:text-destructive rounded-lg hover:bg-destructive/10"
+                            className="p-1.5 text-muted-foreground hover:text-destructive rounded-lg hover:bg-destructive/10 disabled:opacity-50"
+                            disabled={isDeleting}
                           >
                             <Trash2 className="w-3 h-3" />
                           </button>


### PR DESCRIPTION
## Summary

新しいトピック作成時に2回リクエストが送られて、2つの重複したトピックが作成される問題を修正しました。

### 修正内容

- **フロントエンド**: 非同期処理中の重複実行を防止する状態管理を追加
- **UI**: ボタンのdisabled状態制御で重複クリックを防止
- **API**: タイトル重複チェックを実装 (409エラー)
- **UX**: エラーハンドリングを追加してユーザー体験を向上

### 変更ファイル

- `hooks/use-topics.ts`: isCreating, isUpdating, isDeleting状態を追加
- `components/modals/topic-modal.tsx`: 処理中ボタンのdisabled制御
- `components/topic-sidebar.tsx`: 新規作成・削除ボタンの制御
- `components/bookmark-manager-client.tsx`: 状態の連携
- `app/api/topics/route.ts`: 作成時の重複チェック
- `app/api/topics/[id]/route.ts`: 更新時の重複チェック

## Test plan

- [x] 新しいトピック作成ボタンの連続クリック防止を確認
- [x] トピックモーダルの作成ボタンの連続クリック防止を確認
- [x] 同じタイトルのトピック作成時のエラー表示を確認
- [x] トピック更新時の重複チェックを確認
- [x] 削除ボタンの連続クリック防止を確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time feedback and disabled states for topic creation, updating, and deletion buttons to prevent duplicate actions.
  * The modal and sidebar now display processing states ("処理中...") during ongoing operations.

* **Bug Fixes**
  * Prevented creation or updating of topics with duplicate titles, providing clear error messages when a duplicate is detected.

* **Style**
  * Updated button styles to visually indicate disabled states during ongoing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->